### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A character user interface (CUI) tool for browsing and resuming OpenAI Codex CLI
 
 ![cdxresume screenshot](docs/images/demo-screenshot.png)
 
-**⚠️ DISCLAIMER: This is an unofficial third-party tool not affiliated with or endorsed by Anthropic. Use at your own risk.**
+**⚠️ DISCLAIMER: This is an unofficial third-party tool not affiliated with or endorsed by OpenAI. Use at your own risk.**
 
 ## Overview
 
@@ -241,9 +241,6 @@ For issues and feature requests, please use the [GitHub issue tracker](https://g
 
 ## Known Issues
 
-- Preview may occasionally miss the very last assistant text when followed by multiple trailing tool calls. Switching to Full View (key: f) shows everything. We’re investigating; scroll logic will be revisited.
-- Tool results are intentionally hidden to avoid layout breaks. Full View shows apply_patch diffs with colors; Preview shows an apply_patch summary only.
-- Windows native terminal limitations may affect input handling.
 - Resume via `experimental_resume` does not display the full chat history inside Codex CLI after launch. This is an upstream limitation/behavior of the experimental feature.
 
 Remember: This is an unofficial tool. For official OpenAI Codex CLI support, please refer to OpenAI's documentation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README disclaimer to reference OpenAI instead of Anthropic.
  * Removed outdated Known Issues about:
    * Preview missing the last assistant message after trailing tool calls.
    * Tool results being hidden to prevent layout issues (Full View vs Preview).
    * Windows native terminal limitations.
  * Retained note on resuming sessions with experimental_resume.
  * No functional or API changes; documentation clarity improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->