### PR TITLE
fix(tty): prevent stray input bytes after resume/new

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,6 @@ const App: React.FC<AppProps> = ({ codexArgs = [], currentDirOnly = false, hideO
             stdout.write('\u001b[?2004l');   // disable bracketed paste mode
             stdout.write('\u001b[2J');       // clear screen
             stdout.write('\u001b[H');        // move cursor to home
-            stdout.write('\u001bc');         // full terminal reset (ESC c)
           } catch { void 0; }
         }
 
@@ -113,6 +112,14 @@ const App: React.FC<AppProps> = ({ codexArgs = [], currentDirOnly = false, hideO
         if (process.platform !== 'win32') {
           try {
             spawnSync('stty', ['sane'], { stdio: 'ignore' });
+          } catch { /* ignore */ }
+        }
+
+        // Drain any pending keyboard input so escape sequences don't leak into Codex
+        if (process.platform !== 'win32') {
+          try {
+            // Use non-blocking read from /dev/tty to discard pending bytes
+            spawnSync('sh', ['-lc', 'dd if=/dev/tty of=/dev/null bs=1 count=100000 iflag=nonblock 2>/dev/null || true'], { stdio: 'ignore' });
           } catch { /* ignore */ }
         }
 


### PR DESCRIPTION
This PR addresses stray escape/garbage characters appearing in Codex right after resume/new:

- Remove full terminal reset (ESC c/RIS), which can elicit terminal responses (e.g., DA)
- Keep safe TTY reset: raw mode off, cursor on, leave alt buffer, disable bracketed paste, clear screen
- POSIX: drain pending input from /dev/tty in non-blocking mode to avoid leaking buffered bytes into Codex

Validation:
- Lint/typecheck/build: OK
- Tests: 8/8 suites passed

This should reduce cases where numbers/letters/; appear immediately on Codex start. Please review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Resolved occasional terminal glitches where leftover input or escape sequences appeared after restoring settings.
  * Reduced rare flicker by avoiding unnecessary full terminal resets, resulting in a cleaner screen state.
  * Improved resilience: cleanup errors are safely ignored and no longer disrupt normal operation.
  * Changes apply to macOS/Linux; behavior is unchanged on Windows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->