### PR TITLE
mergeback: release 0.1.2 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2025-09-03
+
+Hotfix: prevent stray characters right after resume/new.
+
+### Fixed
+- TTY: remove full terminal reset (ESC c/RIS) that can elicit terminal responses.
+- TTY: drain pending input from /dev/tty (POSIX) before launching Codex to avoid leaking buffered bytes.
+
 ## [0.1.1] - 2025-09-03
 
 Patch release with packaging and stability improvements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdxresume",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A TUI tool for browsing and resuming Codex CLI conversations",
   "type": "module",
   "bin": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -105,7 +105,6 @@ const App: React.FC<AppProps> = ({ codexArgs = [], currentDirOnly = false, hideO
             stdout.write('\u001b[?2004l');   // disable bracketed paste mode
             stdout.write('\u001b[2J');       // clear screen
             stdout.write('\u001b[H');        // move cursor to home
-            stdout.write('\u001bc');         // full terminal reset (ESC c)
           } catch { void 0; }
         }
 
@@ -113,6 +112,14 @@ const App: React.FC<AppProps> = ({ codexArgs = [], currentDirOnly = false, hideO
         if (process.platform !== 'win32') {
           try {
             spawnSync('stty', ['sane'], { stdio: 'ignore' });
+          } catch { /* ignore */ }
+        }
+
+        // Drain any pending keyboard input so escape sequences don't leak into Codex
+        if (process.platform !== 'win32') {
+          try {
+            // Use non-blocking read from /dev/tty to discard pending bytes
+            spawnSync('sh', ['-lc', 'dd if=/dev/tty of=/dev/null bs=1 count=100000 iflag=nonblock 2>/dev/null || true'], { stdio: 'ignore' });
           } catch { /* ignore */ }
         }
 


### PR DESCRIPTION
Merge back the v0.1.2 release changes from master into develop.

- Bump version to 0.1.2
- CHANGELOG: add 0.1.2 notes (TTY input drain, remove RIS, etc.)
- Keep develop in sync with master post-release

This PR is merge-only; no code changes beyond the release artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent stray characters from appearing immediately after starting or resuming a session.
  * Improve terminal compatibility by avoiding resets that trigger terminal responses and by flushing pending input before launch.

* **Documentation**
  * Added changelog entry for version 0.1.2 (Hotfix) detailing the above fixes.

* **Chores**
  * Bumped version to 0.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->