### PR TITLE
feat: support Codex 0.32+ rollout format and selective reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented here.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Compatibility with Codex consolidated log at `~/.codex/history.jsonl` (fallback when `~/.codex/sessions/YYYY/MM/DD/*.jsonl` is absent).
+- Detection of native Codex resume flags; prefer `--resume <sessionId>` / `--session-id <uuid>` when available; fall back to `-c experimental_resume=<path>`.
+
+### Changed
+- Graceful degradation when resume flags aren’t supported by the installed Codex build: start a new session and show a notice.
+
 ## [0.1.2] - 2025-09-03
 
 Hotfix: prevent stray characters right after resume/new.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 ## [Unreleased]
 
 ### Added
-- Compatibility with Codex consolidated log at `~/.codex/history.jsonl` (fallback when `~/.codex/sessions/YYYY/MM/DD/*.jsonl` is absent).
 - Detection of native Codex resume flags; prefer `--resume <sessionId>` / `--session-id <uuid>` when available; fall back to `-c experimental_resume=<path>`.
+- When Codex version cannot be detected, cdxresume probes local logs to select the matching format; if inconclusive, it shows a notice and starts a new session.
 
 ### Changed
-- Graceful degradation when resume flags aren’t supported by the installed Codex build: start a new session and show a notice.
+- Resume now prefers native flags (`--resume` / `--session-id`) when supported; otherwise gracefully degrades to `experimental_resume` (older builds) or starts a new session with a notice.
 
 ## [0.1.2] - 2025-09-03
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Important compatibility note (Codex 0.32.0+):
 ## Disclaimer / Important Notes
 
 - This is an unofficial tool for extending Codex CLI. It is not affiliated with or endorsed by the Codex CLI authors.
- - Official Codex CLI (v0.30.0) now supports `--resume` (interactive picker) and `--continue` (latest session). cdxresume remains compatible and valuable as a session browser and launcher. See release notes: https://github.com/openai/codex/releases/tag/rust-v0.30.0
-- cdxresume prefers native Codex resume flags when available. If your Codex build supports them, cdxresume will launch with `--resume <sessionId>` (or `--session-id <uuid>`). For older Codex builds, it may fall back to `-c experimental_resume=<path-to-jsonl>`.
-- If the installed Codex build doesn’t support resuming by session or file path, cdxresume will start a new session and show a notice.
+- Official Codex CLI (v0.30.0) now supports `--resume` (interactive picker) and `--continue` (latest session). cdxresume remains compatible and valuable as a session browser and launcher. See the release notes: [rust-v0.30.0](https://github.com/openai/codex/releases/tag/rust-v0.30.0).
+- cdxresume prefers native Codex resume flags when available. If your Codex build supports them, cdxresume will launch with `--resume <sessionId>` (or `--session-id <uuid>`). For older Codex builds, it falls back to `-c experimental_resume=<path-to-jsonl>`.
+- If the installed Codex build doesn’t support resuming by session or file path, cdxresume starts a new session and shows a notice.
 - This project was created by adapting and reworking the UI/logic from `ccresume` (a Claude Code tool): https://github.com/sasazame/ccresume. It is not a GitHub fork; it is a new repository derived from the original concept and components.
 
 ### Key Features
@@ -106,7 +106,7 @@ cdxresume . --hide --some-codex-flag
 
 Notes:
 - All unrecognized arguments are forwarded to Codex. If you pass `--resume` or `--continue`, Codex’s native picker/auto-resume takes over (cdxresume’s selection will be ignored).
- - To ensure cdxresume’s chosen session is resumed, avoid `--resume`/`--continue`; rely on the `-c experimental_resume=<path>` that cdxresume supplies.
+- To ensure cdxresume’s chosen session is resumed, avoid passing `--resume`/`--continue` yourself. cdxresume will prefer native `--resume`/`--session-id` automatically when supported, and only fall back to `-c experimental_resume=<path>` on older Codex builds.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,20 @@ A character user interface (CUI) tool for browsing and resuming OpenAI Codex CLI
 
 cdxresume provides an interactive terminal interface to browse and manage your Codex CLI session history. It reads session data from your local Codex CLI logs and displays them in an easy-to-navigate format.
 
+Important compatibility note (Codex 0.32.0+):
+- Codex 0.32.0 introduced a breaking change to the rollout JSONL format saved under `~/.codex/sessions/YYYY/MM/DD/*.jsonl`.
+- Logs created by Codex 0.31.x and earlier (legacy format) are not compatible with the new format (and vice versa).
+- cdxresume detects your installed Codex version and reads only the matching format:
+  - 0.32.0 or newer: reads only the new format
+  - 0.31.x or older: reads only the legacy format
+- Cross‑format conversion is not implemented at this time.
+
 ## Disclaimer / Important Notes
 
 - This is an unofficial tool for extending Codex CLI. It is not affiliated with or endorsed by the Codex CLI authors.
  - Official Codex CLI (v0.30.0) now supports `--resume` (interactive picker) and `--continue` (latest session). cdxresume remains compatible and valuable as a session browser and launcher. See release notes: https://github.com/openai/codex/releases/tag/rust-v0.30.0
-- cdxresume resumes a specific selection by passing Codex’s experimental override: `codex -c experimental_resume=<path-to-jsonl>`.
-  - This path-based resume remains supported upstream and is the correct way to resume an exact rollout file from a third-party launcher.
-  - You can also pass `--resume` or `--continue` directly to Codex if you prefer its native picker/latest behavior; note that doing so ignores the selection made in cdxresume and lets Codex decide.
-  - To use cdxresume’s selection, do not pass `--resume` or `--continue`; cdxresume will supply `-c experimental_resume=<path-to-jsonl>` to Codex for you.
+- cdxresume prefers native Codex resume flags when available. If your Codex build supports them, cdxresume will launch with `--resume <sessionId>` (or `--session-id <uuid>`). For older Codex builds, it may fall back to `-c experimental_resume=<path-to-jsonl>`.
+- If the installed Codex build doesn’t support resuming by session or file path, cdxresume will start a new session and show a notice.
 - This project was created by adapting and reworking the UI/logic from `ccresume` (a Claude Code tool): https://github.com/sasazame/ccresume. It is not a GitHub fork; it is a new repository derived from the original concept and components.
 
 ### Key Features
@@ -240,7 +246,7 @@ For issues and feature requests, please use the [GitHub issue tracker](https://g
 
 ## Known Issues
 
- - Resume history rendering has improved in newer Codex CLI versions (v0.30.0+). If you previously saw limited chat history after resuming, updating Codex may resolve it.
- - Exact transcript visibility is ultimately controlled by Codex. When using `-c experimental_resume=<path>`, behavior may differ from Codex’s built‑in `--resume` picker. If you prefer a Codex‑managed resume flow, pass `--resume` to use the native picker.
+- Codex 0.32.0+ changes the session rollout file format. cdxresume reads only the format that matches your installed Codex version and does not convert logs between formats. Old logs may not appear when running with a newer Codex (and vice versa).
+- Exact transcript visibility is ultimately controlled by Codex. When using `-c experimental_resume=<path>`, behavior may differ from Codex’s built‑in `--resume` picker. If you prefer a Codex‑managed resume flow, pass `--resume` to use the native picker.
 
 Remember: This is an unofficial tool. For official OpenAI Codex CLI support, please refer to OpenAI's documentation.

--- a/src/utils/codexSupport.ts
+++ b/src/utils/codexSupport.ts
@@ -8,11 +8,11 @@ export interface CodexSupport {
 
 let cached: CodexSupport | null = null;
 
-export function detectCodexSupport(): CodexSupport {
+export function detectCodexSupport(helpOverride?: string): CodexSupport {
   if (cached) return cached;
-  let help = '';
+  let help = helpOverride ?? '';
   try {
-    help = execSync('codex --help', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+    if (!help) help = execSync('codex --help', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 2000 });
   } catch {
     // If codex is not available or help fails, assume no flags
     cached = { supportsResumeFlag: false, supportsContinueFlag: false, supportsSessionIdFlag: false };
@@ -20,11 +20,10 @@ export function detectCodexSupport(): CodexSupport {
   }
 
   const normalized = help.toLowerCase();
-  const supportsResumeFlag = /\b--resume\b/.test(normalized) || /\b-\s*r,\s*--resume\b/.test(normalized);
-  const supportsContinueFlag = /\b--continue\b/.test(normalized) || /\b-\s*c,\s*--continue\b/.test(normalized);
+  const supportsResumeFlag = /\b--resume\b/.test(normalized) || /(^|\n)\s*-\s*r(?:\b|,)/.test(normalized);
+  const supportsContinueFlag = /\b--continue\b/.test(normalized) || /(^|\n)\s*-\s*c(?:\b|,)/.test(normalized);
   const supportsSessionIdFlag = /\b--session-id\b/.test(normalized);
 
   cached = { supportsResumeFlag, supportsContinueFlag, supportsSessionIdFlag };
   return cached;
 }
-

--- a/src/utils/codexSupport.ts
+++ b/src/utils/codexSupport.ts
@@ -1,0 +1,30 @@
+import { execSync } from 'child_process';
+
+export interface CodexSupport {
+  supportsResumeFlag: boolean;      // --resume [sessionId]
+  supportsContinueFlag: boolean;    // --continue
+  supportsSessionIdFlag: boolean;   // --session-id <uuid>
+}
+
+let cached: CodexSupport | null = null;
+
+export function detectCodexSupport(): CodexSupport {
+  if (cached) return cached;
+  let help = '';
+  try {
+    help = execSync('codex --help', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch {
+    // If codex is not available or help fails, assume no flags
+    cached = { supportsResumeFlag: false, supportsContinueFlag: false, supportsSessionIdFlag: false };
+    return cached;
+  }
+
+  const normalized = help.toLowerCase();
+  const supportsResumeFlag = /\b--resume\b/.test(normalized) || /\b-\s*r,\s*--resume\b/.test(normalized);
+  const supportsContinueFlag = /\b--continue\b/.test(normalized) || /\b-\s*c,\s*--continue\b/.test(normalized);
+  const supportsSessionIdFlag = /\b--session-id\b/.test(normalized);
+
+  cached = { supportsResumeFlag, supportsContinueFlag, supportsSessionIdFlag };
+  return cached;
+}
+

--- a/src/utils/codexVersion.ts
+++ b/src/utils/codexVersion.ts
@@ -1,0 +1,32 @@
+import { execSync } from 'child_process';
+
+export function getCodexVersion(): string | null {
+  try {
+    const out = execSync('codex --version', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    // Expect a semver-like string, possibly prefixed. Keep simple: first token with digits.
+    const m = out.match(/(\d+\.\d+\.\d+(?:-[^\s]+)?)/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isCodexNewRolloutFormat(version: string | null): boolean {
+  // New format introduced at 0.32.0
+  if (!version) return true; // default to new format on unknown
+  return compareSemver(version, '0.32.0') >= 0;
+}
+
+function compareSemver(a: string, b: string): number {
+  // Very small comparator, ignores build metadata.
+  const pa = a.split('-')[0].split('.').map(n => parseInt(n, 10));
+  const pb = b.split('-')[0].split('.').map(n => parseInt(n, 10));
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] || 0;
+    const db = pb[i] || 0;
+    if (da > db) return 1;
+    if (da < db) return -1;
+  }
+  return 0;
+}
+

--- a/src/utils/codexVersion.ts
+++ b/src/utils/codexVersion.ts
@@ -1,8 +1,11 @@
 import { execSync } from 'child_process';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
 
 export function getCodexVersion(): string | null {
   try {
-    const out = execSync('codex --version', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    const out = execSync('codex --version', { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 1500 }).trim();
     // Expect a semver-like string, possibly prefixed. Keep simple: first token with digits.
     const m = out.match(/(\d+\.\d+\.\d+(?:-[^\s]+)?)/);
     return m ? m[1] : null;
@@ -13,12 +16,12 @@ export function getCodexVersion(): string | null {
 
 export function isCodexNewRolloutFormat(version: string | null): boolean {
   // New format introduced at 0.32.0
-  if (!version) return true; // default to new format on unknown
+  if (!version) return guessFromLocalLogs(); // probe instead of defaulting to new
   return compareSemver(version, '0.32.0') >= 0;
 }
 
 function compareSemver(a: string, b: string): number {
-  // Very small comparator, ignores build metadata.
+  // Very small comparator, ignores pre-release/build metadata (treats 0.32.0-beta == 0.32.0).
   const pa = a.split('-')[0].split('.').map(n => parseInt(n, 10));
   const pb = b.split('-')[0].split('.').map(n => parseInt(n, 10));
   for (let i = 0; i < 3; i++) {
@@ -30,3 +33,48 @@ function compareSemver(a: string, b: string): number {
   return 0;
 }
 
+function guessFromLocalLogs(): boolean {
+  try {
+    // Heuristic 1: if consolidated history.jsonl exists, we assume newer codex
+    const history = join(homedir(), '.codex', 'history.jsonl');
+    if (existsSync(history)) return true;
+
+    // Heuristic 2: sample one session file and inspect the first line
+    const sessionsRoot = join(homedir(), '.codex', 'sessions');
+    // Years descending
+    const years = safeReadDir(sessionsRoot).sort().reverse();
+    for (const y of years) {
+      const months = safeReadDir(join(sessionsRoot, y)).sort().reverse();
+      for (const m of months) {
+        const days = safeReadDir(join(sessionsRoot, y, m)).sort().reverse();
+        for (const d of days) {
+          const dayPath = join(sessionsRoot, y, m, d);
+          const files = safeReadDir(dayPath).filter(f => f.endsWith('.jsonl'));
+          if (files.length === 0) continue;
+          const fpath = join(dayPath, files.sort().reverse()[0]);
+          const first = readFirstLine(fpath);
+          if (!first) continue;
+          try {
+            const obj = JSON.parse(first) as { type?: string };
+            return obj?.type === 'session_meta';
+          } catch { /* ignore */ }
+        }
+      }
+    }
+  } catch { /* ignore */ }
+  return false; // default to legacy if inconclusive
+}
+
+function safeReadDir(path: string): string[] {
+  try { return readdirSync(path); } catch { return []; }
+}
+
+function readFirstLine(path: string): string | null {
+  try {
+    const data = readFileSync(path, 'utf-8');
+    const line = data.split('\n').find(l => l.trim());
+    return line ? line : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/conversationReader.ts
+++ b/src/utils/conversationReader.ts
@@ -3,8 +3,11 @@ import { join, basename } from 'path';
 import { homedir } from 'os';
 import type { Conversation, Message, ContentPart } from '../types.js';
 import { extractMessageText } from './messageUtils.js';
+import { getCodexVersion, isCodexNewRolloutFormat } from './codexVersion.js';
 
 const CODEX_SESSIONS_DIR = join(homedir(), '.codex', 'sessions');
+// For now we intentionally do NOT rely on history.jsonl. We selectively parse
+// either the legacy format (pre-0.32) or the new rollout format (0.32+).
 
 interface PaginationOptions {
   limit: number;
@@ -28,86 +31,29 @@ function projectNameFromRepoUrl(url?: string): string {
 }
 
 export async function getPaginatedConversations(options: PaginationOptions): Promise<{ conversations: Conversation[]; total: number; }> {
-  const allFiles: Array<{ path: string; dir: string; mtime: Date }>= [];
-  try {
-    const years = await readdir(CODEX_SESSIONS_DIR);
-    for (const year of years) {
-      const yearPath = join(CODEX_SESSIONS_DIR, year);
-      let months: string[] = [];
-      try { months = await readdir(yearPath); } catch { /* ignore non-dirs */ continue; }
-      for (const month of months) {
-        const monthPath = join(yearPath, month);
-        let days: string[] = [];
-        try { days = await readdir(monthPath); } catch { /* ignore non-dirs */ continue; }
-        for (const day of days) {
-          const dayPath = join(monthPath, day);
-          let files: string[] = [];
-          try { files = await readdir(dayPath); } catch { /* ignore non-dirs */ continue; }
-          const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
-          for (const file of jsonlFiles) {
-            const filePath = join(dayPath, file);
-            const stats = await stat(filePath);
-            allFiles.push({ path: filePath, dir: `${year}/${month}/${day}`, mtime: stats.mtime });
-          }
-        }
-      }
-    }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { conversations: [], total: 0 };
-    }
-    throw error;
-  }
+  const version = getCodexVersion();
+  const useNew = isCodexNewRolloutFormat(version);
+  const all = useNew
+    ? await collectNewFormatConversations()
+    : await collectLegacyFormatConversations();
 
-  allFiles.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+  const filtered = options.currentDirFilter ? all.filter(c => c.projectPath === options.currentDirFilter) : all;
+  filtered.sort((a, b) => b.endTime.getTime() - a.endTime.getTime());
 
-  const conversations: Conversation[] = [];
-  let skippedCount = 0;
-  let fileIndex = 0;
-
-  while (skippedCount < options.offset && fileIndex < allFiles.length) {
-    const file = allFiles[fileIndex];
-    const conv = await readConversation(file.path);
-    if (conv) skippedCount++;
-    fileIndex++;
-  }
-
-  while (conversations.length < options.limit && fileIndex < allFiles.length) {
-    const file = allFiles[fileIndex];
-    const conv = await readConversation(file.path);
-    if (conv) conversations.push(conv);
-    fileIndex++;
-  }
-
-  return { conversations, total: -1 };
+  const total = filtered.length;
+  const start = Math.min(options.offset, total);
+  const end = Math.min(start + options.limit, total);
+  return { conversations: filtered.slice(start, end), total };
 }
 
 export async function getAllConversations(currentDirFilter?: string): Promise<Conversation[]> {
-  const conversations: Conversation[] = [];
   try {
-    const years = await readdir(CODEX_SESSIONS_DIR);
-    for (const year of years) {
-      const yearPath = join(CODEX_SESSIONS_DIR, year);
-      let months: string[] = [];
-      try { months = await readdir(yearPath); } catch { /* ignore */ continue; }
-      for (const month of months) {
-        const monthPath = join(yearPath, month);
-        let days: string[] = [];
-        try { days = await readdir(monthPath); } catch { /* ignore */ continue; }
-        for (const day of days) {
-          const dayPath = join(monthPath, day);
-          let files: string[] = [];
-          try { files = await readdir(dayPath); } catch { /* ignore */ continue; }
-          const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
-          for (const file of jsonlFiles) {
-            const filePath = join(dayPath, file);
-            const conv = await readConversation(filePath);
-            if (conv) conversations.push(conv);
-          }
-        }
-      }
-    }
-    const filtered = currentDirFilter ? conversations.filter(c => c.projectPath === currentDirFilter) : conversations;
+    const version = getCodexVersion();
+    const useNew = isCodexNewRolloutFormat(version);
+    const list = useNew
+      ? await collectNewFormatConversations()
+      : await collectLegacyFormatConversations();
+    const filtered = currentDirFilter ? list.filter(c => c.projectPath === currentDirFilter) : list;
     return filtered.sort((a, b) => b.endTime.getTime() - a.endTime.getTime());
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
@@ -115,7 +61,74 @@ export async function getAllConversations(currentDirFilter?: string): Promise<Co
   }
 }
 
-async function readConversation(filePath: string): Promise<Conversation | null> {
+async function collectLegacyFormatConversations(): Promise<Conversation[]> {
+  const conversations: Conversation[] = [];
+  try {
+    const years = await readdir(CODEX_SESSIONS_DIR);
+    for (const year of years) {
+      const yearPath = join(CODEX_SESSIONS_DIR, year);
+      let months: string[] = [];
+      try { months = await readdir(yearPath); } catch { continue; }
+      for (const month of months) {
+        const monthPath = join(yearPath, month);
+        let days: string[] = [];
+        try { days = await readdir(monthPath); } catch { continue; }
+        for (const day of days) {
+          const dayPath = join(monthPath, day);
+          let files: string[] = [];
+          try { files = await readdir(dayPath); } catch { continue; }
+          const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
+          for (const file of jsonlFiles) {
+            const filePath = join(dayPath, file);
+            // For legacy parser, skip files that are clearly new-format (fast check first line)
+            const isNew = await isNewFormatFile(filePath);
+            if (isNew) continue;
+            const conv = await readConversationLegacy(filePath);
+            if (conv) conversations.push(conv);
+          }
+        }
+      }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  return conversations;
+}
+
+async function collectNewFormatConversations(): Promise<Conversation[]> {
+  const conversations: Conversation[] = [];
+  try {
+    const years = await readdir(CODEX_SESSIONS_DIR);
+    for (const year of years) {
+      const yearPath = join(CODEX_SESSIONS_DIR, year);
+      let months: string[] = [];
+      try { months = await readdir(yearPath); } catch { continue; }
+      for (const month of months) {
+        const monthPath = join(yearPath, month);
+        let days: string[] = [];
+        try { days = await readdir(monthPath); } catch { continue; }
+        for (const day of days) {
+          const dayPath = join(monthPath, day);
+          let files: string[] = [];
+          try { files = await readdir(dayPath); } catch { continue; }
+          const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
+          for (const file of jsonlFiles) {
+            const filePath = join(dayPath, file);
+            const isNew = await isNewFormatFile(filePath);
+            if (!isNew) continue;
+            const conv = await readConversationNew(filePath);
+            if (conv) conversations.push(conv);
+          }
+        }
+      }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  return conversations;
+}
+
+async function readConversationLegacy(filePath: string): Promise<Conversation | null> {
   try {
     const content = await readFile(filePath, 'utf-8');
     const lines = content.trim().split('\n').filter(line => line.trim());
@@ -253,8 +266,231 @@ async function readConversation(filePath: string): Promise<Conversation | null> 
       endTime
     };
   } catch (error) {
-    console.error(`Error reading conversation file ${filePath}:`, error);
+    console.error(`Error reading legacy conversation file ${filePath}:`, error);
     return null;
+  }
+}
+
+async function readConversationNew(filePath: string): Promise<Conversation | null> {
+  try {
+    const content = await readFile(filePath, 'utf-8');
+    const lines = content.trim().split('\n').filter(l => l.trim());
+    if (lines.length === 0) return null;
+
+    interface NewLineBase { timestamp?: string; type?: string; payload?: unknown }
+    interface SessionMetaPayload { id?: string; timestamp?: string; cwd?: string; instructions?: string; git?: { branch?: string; repository_url?: string } }
+    // ResponseItem payloads are variant; we'll treat them as 'any' in parsing logic below.
+
+    let sessionId = '';
+    let startTimestamp = new Date();
+    let cwd = '';
+    let repoUrl: string | undefined;
+    let gitBranch: string | undefined;
+
+    // Parse session_meta from the first line
+    try {
+      const first = JSON.parse(lines[0]) as NewLineBase;
+      if (first && first.type === 'session_meta' && first.payload && typeof first.payload === 'object') {
+        const p = first.payload as SessionMetaPayload;
+        sessionId = typeof p.id === 'string' ? p.id : '';
+        if (typeof p.timestamp === 'string') startTimestamp = new Date(p.timestamp);
+        cwd = typeof p.cwd === 'string' ? p.cwd : '';
+        if (p.git) {
+          if (typeof p.git.repository_url === 'string') repoUrl = p.git.repository_url;
+          if (typeof p.git.branch === 'string') gitBranch = p.git.branch;
+        }
+      } else {
+        // Not a new-format file
+        return null;
+      }
+    } catch {
+      return null;
+    }
+
+    const messages: Message[] = [];
+    let counter = 0;
+
+    // Iterate remaining lines
+    for (let i = 1; i < lines.length; i++) {
+      let parsed: unknown;
+      try { parsed = JSON.parse(lines[i]); } catch { continue; }
+      if (!parsed || typeof parsed !== 'object') continue;
+      const data = parsed as NewLineBase;
+      const ts = typeof data.timestamp === 'string' ? data.timestamp : new Date(startTimestamp.getTime() + counter).toISOString();
+
+      if (data.type === 'response_item' && data.payload && typeof data.payload === 'object') {
+        const payload = data.payload as Record<string, unknown>;
+        const pType = typeof payload.type === 'string' ? (payload.type as string).toLowerCase() : '';
+
+        // 1) Chat messages (user/assistant)
+        if (pType === 'message' && (payload.role === 'user' || payload.role === 'assistant')) {
+          // Hide initial environment_context messages from history (parity with legacy)
+          const contentArr = Array.isArray(payload.content) ? (payload.content as unknown[]) : [];
+          const isEnv = contentArr.some((it) => typeof (it as { text?: unknown })?.text === 'string' && ((it as { text?: string }).text as string).includes('<environment_context>'));
+          if (isEnv) { counter++; continue; }
+
+          const parts: ContentPart[] = contentArr.map((p): ContentPart | null => {
+            const t = typeof (p as { type?: unknown })?.type === 'string' ? ((p as { type?: string }).type as string).toLowerCase() : '';
+            const text = typeof (p as { text?: unknown })?.text === 'string' ? (p as { text?: string }).text : undefined;
+            if (t === 'input_text') return { type: 'input_text', text };
+            if (t === 'output_text') return { type: 'output_text', text };
+            if (t === 'text') return { type: 'text', text };
+            return null;
+          }).filter(Boolean) as ContentPart[];
+
+          messages.push({
+            sessionId,
+            timestamp: ts,
+            type: payload.role,
+            message: { role: payload.role, content: parts },
+            cwd
+          });
+          counter++;
+          continue;
+        }
+
+        // 2) Reasoning — skip (parity with legacy)
+        if (pType === 'reasoning') {
+          counter++;
+          continue;
+        }
+
+        // 3) Function/tool calls → map to tool_use
+        if (pType === 'function_call') {
+          let input: unknown = undefined;
+          try {
+            if (typeof payload.arguments === 'string') input = JSON.parse(payload.arguments as string);
+          } catch { /* ignore */ }
+          const name = typeof payload.name === 'string' ? (payload.name as string) : 'tool';
+          const callId = typeof payload.call_id === 'string' ? (payload.call_id as string) : undefined;
+          messages.push({
+            sessionId,
+            timestamp: ts,
+            type: 'assistant',
+            message: { role: 'assistant', content: [{ type: 'tool_use', name, input, tool_use_id: callId }] as ContentPart[] },
+            cwd
+          });
+          counter++;
+          continue;
+        }
+
+        if (pType === 'function_call_output') {
+          // We deliberately do not render stdout/stderr in preview (parity with legacy)
+          messages.push({
+            sessionId,
+            timestamp: ts,
+            type: 'assistant',
+            message: { role: 'assistant', content: [{ type: 'tool_result' }] as ContentPart[] },
+            cwd,
+            toolUseResult: { content: 'tool call finished' }
+          });
+          counter++;
+          continue;
+        }
+
+        if (pType === 'custom_tool_call') {
+          const name = typeof payload.name === 'string' ? `custom:${payload.name as string}` : 'custom_tool';
+          let input: unknown = undefined;
+          try {
+            if (typeof payload.input === 'string') input = JSON.parse(payload.input as string);
+          } catch { input = payload.input as unknown; }
+          const callId = typeof payload.call_id === 'string' ? (payload.call_id as string) : undefined;
+          messages.push({
+            sessionId,
+            timestamp: ts,
+            type: 'assistant',
+            message: { role: 'assistant', content: [{ type: 'tool_use', name, input, tool_use_id: callId }] as ContentPart[] },
+            cwd
+          });
+          counter++;
+          continue;
+        }
+
+        if (pType === 'custom_tool_call_output') {
+          messages.push({
+            sessionId,
+            timestamp: ts,
+            type: 'assistant',
+            message: { role: 'assistant', content: [{ type: 'tool_result' }] as ContentPart[] },
+            cwd,
+            toolUseResult: { content: 'tool call finished' }
+          });
+          counter++;
+          continue;
+        }
+
+        if (pType === 'local_shell_call') {
+          // Map to [Tool: shell] with command vector if available
+          const action = (payload.action as Record<string, unknown>) || {};
+          const command = Array.isArray(action.command) ? (action.command as unknown[]) : undefined;
+          messages.push({
+            sessionId,
+            timestamp: ts,
+            type: 'assistant',
+            message: { role: 'assistant', content: [{ type: 'tool_use', name: 'shell', input: { command } }] as ContentPart[] },
+            cwd
+          });
+          counter++;
+          continue;
+        }
+
+        if (pType === 'web_search_call') {
+          const action = (payload.action as Record<string, unknown>) || {};
+          const query = typeof action.query === 'string' ? (action.query as string) : undefined;
+          messages.push({
+            sessionId,
+            timestamp: ts,
+            type: 'assistant',
+            message: { role: 'assistant', content: [{ type: 'tool_use', name: 'web_search', input: { query } }] as ContentPart[] },
+            cwd
+          });
+          counter++;
+          continue;
+        }
+
+        // Other response_item variants — ignore for now to keep parity/noise low
+        counter++;
+        continue;
+      }
+
+      // Skip event_msg lines in new format (parity with legacy which hid tool output details)
+      if (data.type === 'event_msg') { counter++; continue; }
+    }
+
+    if (messages.length === 0) return null;
+
+    const startTime = startTimestamp;
+    let endTime = startTime;
+    try { const s = await stat(filePath); endTime = s.mtime; } catch { /* ignore */ }
+    const projectName = projectNameFromRepoUrl(repoUrl);
+
+    return {
+      sessionId,
+      sourcePath: filePath,
+      projectPath: cwd,
+      projectName,
+      gitBranch: gitBranch || '-',
+      messages,
+      firstMessage: extractMessageText(messages.find(m => m.type === 'user')?.message?.content) || '',
+      lastMessage: extractMessageText(messages.filter(m => m.type === 'user').slice(-1)[0]?.message?.content) || '',
+      startTime,
+      endTime
+    };
+  } catch (error) {
+    console.error(`Error reading new-format conversation file ${filePath}:`, error);
+    return null;
+  }
+}
+
+async function isNewFormatFile(filePath: string): Promise<boolean> {
+  try {
+    const content = await readFile(filePath, 'utf-8');
+    const first = content.split('\n').find(l => l.trim());
+    if (!first) return false;
+    const obj = JSON.parse(first) as { type?: string };
+    return obj && obj.type === 'session_meta';
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
- Parse new rollout JSONL (session_meta/response_item) to user/assistant and tool events\n- Skip reasoning and low-value events for parity with legacy\n- Detect Codex version; read only matching format (legacy <0.32, new >=0.32)\n- Update README: breaking change at 0.32.0; no cross-format conversion yet\n\nTests, typecheck, lint all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of Codex CLI capabilities and log formats; supports both new rollout and legacy session logs.
  * Resume behavior now prefers native resume flags (--resume / --session-id) and probes local logs when needed.

* **Improvements**
  * Dual-format conversation loading with project/branch extraction and sorted timelines.
  * Clearer runtime status messages indicating resume method or when a new session is started.

* **Bug Fixes**
  * More robust startup and graceful fallback when resume flags aren’t available.

* **Documentation**
  * Updated README, known issues, and changelog with compatibility and resume behavior notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->